### PR TITLE
feat: update proto and add row based insert api

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,14 +12,14 @@ dashmap = "5.4"
 enum_dispatch = "0.3"
 futures = "0.3"
 futures-util  = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", tag = "0.2.1" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", tag = "v0.4.1" }
 parking_lot = "0.12"
-prost = "0.11"
+prost = "0.12"
 rand = "0.8"
 snafu = "0.7"
 tokio = { version = "1", features = ["rt", "time"] }
 tokio-stream = { version = "0.1", features = ["net"] }
-tonic = { version = "0.9", features = ["tls"] }
+tonic = { version = "0.10", features = ["tls"] }
 tower = "0.4"
 
 [build-dependencies]

--- a/examples/ingest.rs
+++ b/examples/ingest.rs
@@ -15,6 +15,7 @@
 use derive_new::new;
 
 use greptimedb_client::api::v1::*;
+use greptimedb_client::helpers::values::*;
 use greptimedb_client::{Client, Database, DEFAULT_SCHEMA_NAME};
 
 #[tokio::main]
@@ -102,20 +103,10 @@ fn to_insert_request(records: Vec<WeatherRecord>) -> RowInsertRequests {
         .into_iter()
         .map(|record| Row {
             values: vec![
-                Value {
-                    value_data: Some(value::ValueData::TimestampMillisecondValue(
-                        record.timestamp_millis,
-                    )),
-                },
-                Value {
-                    value_data: Some(value::ValueData::StringValue(record.collector)),
-                },
-                Value {
-                    value_data: Some(value::ValueData::F32Value(record.temperature)),
-                },
-                Value {
-                    value_data: Some(value::ValueData::I32Value(record.humidity)),
-                },
+                timestamp_millisecond_value(record.timestamp_millis),
+                string_value(record.collector),
+                f32_value(record.temperature),
+                i32_value(record.humidity),
             ],
         })
         .collect();

--- a/examples/stream_ingest.rs
+++ b/examples/stream_ingest.rs
@@ -14,7 +14,6 @@
 
 use derive_new::new;
 
-use greptimedb_client::api::v1::column::*;
 use greptimedb_client::api::v1::*;
 use greptimedb_client::{Client, Database, DEFAULT_SCHEMA_NAME};
 
@@ -125,7 +124,7 @@ fn to_insert_request(records: Vec<WeatherRecord>) -> InsertRequest {
         Column {
             column_name: "ts".to_owned(),
             values: Some(column::Values {
-                ts_millisecond_values: timestamp_millis,
+                timestamp_millisecond_values: timestamp_millis,
                 ..Default::default()
             }),
             semantic_type: SemanticType::Timestamp as i32,

--- a/src/database.rs
+++ b/src/database.rs
@@ -15,7 +15,7 @@
 use crate::api::v1::auth_header::AuthScheme;
 use crate::api::v1::greptime_request::Request;
 use crate::api::v1::{
-    greptime_response, AffectedRows, AuthHeader, DeleteRequest, GreptimeRequest, InsertRequest,
+    greptime_response, AffectedRows, AuthHeader, DeleteRequests, GreptimeRequest, InsertRequest,
     InsertRequests, RequestHeader,
 };
 use crate::stream_insert::StreamInserter;
@@ -104,8 +104,8 @@ impl Database {
     }
 
     /// Issue a delete to database
-    pub async fn delete(&self, request: DeleteRequest) -> Result<u32> {
-        self.handle(Request::Delete(request)).await
+    pub async fn delete(&self, request: DeleteRequests) -> Result<u32> {
+        self.handle(Request::Deletes(request)).await
     }
 
     async fn handle(&self, request: Request) -> Result<u32> {

--- a/src/database.rs
+++ b/src/database.rs
@@ -16,7 +16,7 @@ use crate::api::v1::auth_header::AuthScheme;
 use crate::api::v1::greptime_request::Request;
 use crate::api::v1::{
     greptime_response, AffectedRows, AuthHeader, DeleteRequests, GreptimeRequest, InsertRequest,
-    InsertRequests, RequestHeader,
+    InsertRequests, RequestHeader, RowInsertRequests,
 };
 use crate::stream_insert::StreamInserter;
 
@@ -72,9 +72,15 @@ impl Database {
     }
 
     /// Write insert requests to GreptimeDB and get rows written
+    #[deprecated(note = "Use row_insert instead.")]
     pub async fn insert(&self, requests: Vec<InsertRequest>) -> Result<u32> {
         self.handle(Request::Inserts(InsertRequests { inserts: requests }))
             .await
+    }
+
+    /// Write Row based insert reuqests to GreptimeDB and get rows written
+    pub async fn row_insert(&self, requests: RowInsertRequests) -> Result<u32> {
+        self.handle(Request::RowInserts(requests)).await
     }
 
     /// Initialise a streaming insert handle, using default buffer size `1024`

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -1,0 +1,1 @@
+pub mod values;

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -1,1 +1,15 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 pub mod values;

--- a/src/helpers/values.rs
+++ b/src/helpers/values.rs
@@ -1,0 +1,104 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use greptime_proto::v1::{Decimal128, IntervalMonthDayNano};
+
+macro_rules! define_value_fn {
+    ($fn_name:ident, $arg_type:ty, $inner_type:ident) => {
+        #[inline]
+        pub fn $fn_name(v: $arg_type) -> crate::api::v1::Value {
+            crate::api::v1::Value {
+                value_data: Some(crate::api::v1::value::ValueData::$inner_type(v)),
+            }
+        }
+    };
+    ($fn_name:ident, $arg_type:ty, $inner_type:ident, $convert_type:ty) => {
+        #[inline]
+        pub fn $fn_name(v: $arg_type) -> crate::api::v1::Value {
+            crate::api::v1::Value {
+                value_data: Some(crate::api::v1::value::ValueData::$inner_type(
+                    v as $convert_type,
+                )),
+            }
+        }
+    };
+}
+
+pub fn none_value() -> crate::api::v1::Value {
+    crate::api::v1::Value { value_data: None }
+}
+
+define_value_fn!(i8_value, i8, I8Value, i32);
+define_value_fn!(i16_value, i16, I16Value, i32);
+define_value_fn!(i32_value, i32, I32Value);
+define_value_fn!(i64_value, i64, I64Value);
+
+define_value_fn!(u8_value, u8, U8Value, u32);
+define_value_fn!(u16_value, u16, U16Value, u32);
+define_value_fn!(u32_value, u32, U32Value);
+define_value_fn!(u64_value, u64, U64Value);
+
+define_value_fn!(f32_value, f32, F32Value);
+define_value_fn!(f64_value, f64, F64Value);
+
+define_value_fn!(bool_value, bool, BoolValue);
+
+define_value_fn!(string_value, String, StringValue);
+define_value_fn!(binary_value, Vec<u8>, BinaryValue);
+
+define_value_fn!(date_value, i32, DateValue);
+define_value_fn!(datetime_value, i64, DatetimeValue);
+define_value_fn!(timestamp_second_value, i64, TimestampSecondValue);
+define_value_fn!(timestamp_millisecond_value, i64, TimestampMillisecondValue);
+define_value_fn!(timestamp_microsecond_value, i64, TimestampMicrosecondValue);
+define_value_fn!(timestamp_nanosecond_value, i64, TimestampNanosecondValue);
+define_value_fn!(time_second_value, i64, TimeSecondValue);
+define_value_fn!(time_millisecond_value, i64, TimeMillisecondValue);
+define_value_fn!(time_microsecond_value, i64, TimeMicrosecondValue);
+define_value_fn!(time_nanosecond_value, i64, TimeNanosecondValue);
+define_value_fn!(interval_year_month_value, i32, IntervalYearMonthValues);
+define_value_fn!(interval_day_time_value, i64, IntervalDayTimeValues);
+define_value_fn!(duration_second_value, i64, DurationSecondValue);
+define_value_fn!(duration_millisecond_value, i64, DurationMillisecondValue);
+define_value_fn!(duration_microsecond_value, i64, DurationMicrosecondValue);
+define_value_fn!(duration_nanosecond_value, i64, DurationNanosecondValue);
+
+#[inline]
+pub fn interval_month_day_nano_value(
+    months: i32,
+    days: i32,
+    nanoseconds: i64,
+) -> crate::api::v1::Value {
+    crate::api::v1::Value {
+        value_data: Some(
+            crate::api::v1::value::ValueData::IntervalMonthDayNanoValues(IntervalMonthDayNano {
+                months,
+                days,
+                nanoseconds,
+            }),
+        ),
+    }
+}
+
+#[inline]
+pub fn decimal128_value(v: i128) -> crate::api::v1::Value {
+    crate::api::v1::Value {
+        value_data: Some(crate::api::v1::value::ValueData::Decimal128Value(
+            Decimal128 {
+                hi: (v >> 64) as i64,
+                lo: v as i64,
+            },
+        )),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod channel_manager;
 mod client;
 mod database;
 mod error;
+pub mod helpers;
 pub mod load_balance;
 mod stream_insert;
 


### PR DESCRIPTION
Fixes #11 #12 

- Updates proto to v0.4.1
- Add `row_insert` api and deprecated `insert`
- Updated examples to latest apis
- Added helper functions for values